### PR TITLE
Fix sending empty messages

### DIFF
--- a/ws/common.go
+++ b/ws/common.go
@@ -38,6 +38,9 @@ type ConnectionFactoryFunc func() (*websocket.Conn, error)
 
 // SendTextMessage data over opened conn
 func SendTextMessage(conn *websocket.Conn, payload []byte) error {
+	if len(payload) == 0 {
+        	return nil 
+	}
 	return write(conn, websocket.TextMessage, payload)
 }
 


### PR DESCRIPTION
If payload has length is 0 it WS send an empty message.